### PR TITLE
Add preset tests

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/preset.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/preset.py
@@ -33,11 +33,11 @@ from datahub.ingestion.source.superset import SupersetSource
 logger = logging.getLogger(__name__)
 class PresetConfig(StatefulIngestionConfigBase, ConfigModel):
     manager_uri: str = Field(
-        default="https://api.app.preset.io/", description="Preset.io API URL"
+        default="https://api.app.preset.io", description="Preset.io API URL"
     )
-    connect_uri: str = Field(default=None, description="Preset workspace URL.")
+    connect_uri: str = Field(default='https://api.app.preset.io', description="Preset workspace URL.")
     display_uri: Optional[str] = Field(
-        default=None,
+        default='https://api.app.preset.io',
         description="optional URL to use in links (if `connect_uri` is only for ingestion)",
     )
     api_key: Optional[str] = Field(default=None, description="Preset.io API key.")
@@ -113,7 +113,7 @@ class PresetSource(SupersetSource):
             }
         )
 
-        # Test the connection
-        test_response = self.session.get(f"{self.config.connect_uri}/version")
-        if not test_response.ok:
-            logger.error("Unable to connect to workspace")
+        # # Test the connection
+        # test_response = self.session.get(f"{self.config.connect_uri}/version")
+        # if not test_response.ok:
+        #     logger.error("Unable to connect to workspace")

--- a/metadata-ingestion/src/datahub/ingestion/source/preset.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/preset.py
@@ -113,7 +113,7 @@ class PresetSource(SupersetSource):
             }
         )
 
-        # # Test the connection
-        # test_response = self.session.get(f"{self.config.connect_uri}/version")
-        # if not test_response.ok:
-        #     logger.error("Unable to connect to workspace")
+        # Test the connection
+        test_response = self.session.get(f"{self.config.connect_uri}/version")
+        if not test_response.ok:
+            logger.error("Unable to connect to workspace")

--- a/metadata-ingestion/src/datahub/ingestion/source/preset.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/preset.py
@@ -35,9 +35,9 @@ class PresetConfig(StatefulIngestionConfigBase, ConfigModel):
     manager_uri: str = Field(
         default="https://api.app.preset.io", description="Preset.io API URL"
     )
-    connect_uri: str = Field(default='https://api.app.preset.io', description="Preset workspace URL.")
+    connect_uri: str = Field(default=None, description="Preset workspace URL.")
     display_uri: Optional[str] = Field(
-        default='https://api.app.preset.io',
+        default=None,
         description="optional URL to use in links (if `connect_uri` is only for ingestion)",
     )
     api_key: Optional[str] = Field(default=None, description="Preset.io API key.")

--- a/metadata-ingestion/src/datahub/ingestion/source/superset.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/superset.py
@@ -108,7 +108,7 @@ class SupersetConfig(
     api_key: Optional[str] = Field(default=None, description="Preset.io API key.")
     api_secret: Optional[str] = Field(default=None, description="Preset.io API secret.")
     manager_uri: str = Field(
-        default="https://api.app.preset.io/", description="Preset.io API URL"
+        default="https://api.app.preset.io", description="Preset.io API URL"
     )
     # Configuration for stateful ingestion
     stateful_ingestion: Optional[StatefulStaleMetadataRemovalConfig] = Field(

--- a/metadata-ingestion/tests/integration/preset/golden_test_ingest.json
+++ b/metadata-ingestion/tests/integration/preset/golden_test_ingest.json
@@ -1,0 +1,286 @@
+[
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DashboardSnapshot": {
+            "urn": "urn:li:dashboard:(preset,1)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.dashboard.DashboardInfo": {
+                        "customProperties": {
+                            "Status": "published",
+                            "IsPublished": "true",
+                            "Owners": "test_username_1, test_username_2",
+                            "IsCertified": "true",
+                            "CertifiedBy": "Certification team",
+                            "CertificationDetails": "Approved"
+                        },
+                        "title": "test_dashboard_title_1",
+                        "description": "",
+                        "charts": [
+                            "urn:li:chart:(preset,10)",
+                            "urn:li:chart:(preset,11)"
+                        ],
+                        "datasets": [],
+                        "lastModified": {
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1586847600000,
+                                "actor": "urn:li:corpuser:test_username_1"
+                            }
+                        },
+                        "dashboardUrl": "mock://mock-domain.preset.io/dashboard/test_dashboard_url_1"
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "preset-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DashboardSnapshot": {
+            "urn": "urn:li:dashboard:(preset,2)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.dashboard.DashboardInfo": {
+                        "customProperties": {
+                            "Status": "draft",
+                            "IsPublished": "false",
+                            "Owners": "unknown",
+                            "IsCertified": "false"
+                        },
+                        "title": "test_dashboard_title_2",
+                        "description": "",
+                        "charts": [
+                            "urn:li:chart:(preset,12)",
+                            "urn:li:chart:(preset,13)"
+                        ],
+                        "datasets": [],
+                        "lastModified": {
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1586847600000,
+                                "actor": "urn:li:corpuser:test_username_2"
+                            }
+                        },
+                        "dashboardUrl": "mock://mock-domain.preset.io/dashboard/test_dashboard_url_2"
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "preset-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.ChartSnapshot": {
+            "urn": "urn:li:chart:(preset,10)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.chart.ChartInfo": {
+                        "customProperties": {
+                            "Metrics": "",
+                            "Filters": "",
+                            "Dimensions": ""
+                        },
+                        "title": "test_chart_title_1",
+                        "description": "",
+                        "lastModified": {
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1586847600000,
+                                "actor": "urn:li:corpuser:test_username_1"
+                            }
+                        },
+                        "chartUrl": "mock://mock-domain.preset.io/explore/test_chart_url_10",
+                        "inputs": [
+                            {
+                                "string": "urn:li:dataset:(urn:li:dataPlatform:external,test_database_name.test_schema_name.test_table_name,PROD)"
+                            }
+                        ],
+                        "type": "BAR"
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "preset-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.ChartSnapshot": {
+            "urn": "urn:li:chart:(preset,11)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.chart.ChartInfo": {
+                        "customProperties": {
+                            "Metrics": "",
+                            "Filters": "",
+                            "Dimensions": ""
+                        },
+                        "title": "test_chart_title_2",
+                        "description": "",
+                        "lastModified": {
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1586847600000,
+                                "actor": "urn:li:corpuser:test_username_1"
+                            }
+                        },
+                        "chartUrl": "mock://mock-domain.preset.io/explore/test_chart_url_11",
+                        "inputs": [
+                            {
+                                "string": "urn:li:dataset:(urn:li:dataPlatform:external,test_database_name.test_schema_name.test_table_name,PROD)"
+                            }
+                        ],
+                        "type": "PIE"
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "preset-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.ChartSnapshot": {
+            "urn": "urn:li:chart:(preset,12)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.chart.ChartInfo": {
+                        "customProperties": {
+                            "Metrics": "",
+                            "Filters": "",
+                            "Dimensions": ""
+                        },
+                        "title": "test_chart_title_3",
+                        "description": "",
+                        "lastModified": {
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1586847600000,
+                                "actor": "urn:li:corpuser:test_username_2"
+                            }
+                        },
+                        "chartUrl": "mock://mock-domain.preset.io/explore/test_chart_url_12",
+                        "inputs": [
+                            {
+                                "string": "urn:li:dataset:(urn:li:dataPlatform:external,test_database_name.test_schema_name.test_table_name,PROD)"
+                            }
+                        ],
+                        "type": "AREA"
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "preset-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.ChartSnapshot": {
+            "urn": "urn:li:chart:(preset,13)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.chart.ChartInfo": {
+                        "customProperties": {
+                            "Metrics": "",
+                            "Filters": "",
+                            "Dimensions": ""
+                        },
+                        "title": "test_chart_title_4",
+                        "description": "",
+                        "lastModified": {
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1586847600000,
+                                "actor": "urn:li:corpuser:test_username_2"
+                            }
+                        },
+                        "chartUrl": "mock://mock-domain.preset.io/explore/test_chart_url_13",
+                        "inputs": [
+                            {
+                                "string": "urn:li:dataset:(urn:li:dataPlatform:external,test_database_name.test_schema_name.test_table_name,PROD)"
+                            }
+                        ],
+                        "type": "HISTOGRAM"
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "preset-test",
+        "lastRunId": "no-run-id-provided"
+    }
+}
+]

--- a/metadata-ingestion/tests/integration/preset/golden_test_ingest.json
+++ b/metadata-ingestion/tests/integration/preset/golden_test_ingest.json
@@ -32,7 +32,7 @@
                                 "actor": "urn:li:corpuser:unknown"
                             },
                             "lastModified": {
-                                "time": 1586847600000,
+                                "time": 1720594800000,
                                 "actor": "urn:li:corpuser:test_username_1"
                             }
                         },
@@ -43,7 +43,7 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1586847600000,
+        "lastObserved": 1720594800000,
         "runId": "preset-test",
         "lastRunId": "no-run-id-provided"
     }
@@ -79,7 +79,7 @@
                                 "actor": "urn:li:corpuser:unknown"
                             },
                             "lastModified": {
-                                "time": 1586847600000,
+                                "time": 1720594800000,
                                 "actor": "urn:li:corpuser:test_username_2"
                             }
                         },
@@ -90,7 +90,7 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1586847600000,
+        "lastObserved": 1720594800000,
         "runId": "preset-test",
         "lastRunId": "no-run-id-provided"
     }
@@ -120,7 +120,7 @@
                                 "actor": "urn:li:corpuser:unknown"
                             },
                             "lastModified": {
-                                "time": 1586847600000,
+                                "time": 1720594800000,
                                 "actor": "urn:li:corpuser:test_username_1"
                             }
                         },
@@ -137,7 +137,7 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1586847600000,
+        "lastObserved": 1720594800000,
         "runId": "preset-test",
         "lastRunId": "no-run-id-provided"
     }
@@ -167,7 +167,7 @@
                                 "actor": "urn:li:corpuser:unknown"
                             },
                             "lastModified": {
-                                "time": 1586847600000,
+                                "time": 1720594800000,
                                 "actor": "urn:li:corpuser:test_username_1"
                             }
                         },
@@ -184,7 +184,7 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1586847600000,
+        "lastObserved": 1720594800000,
         "runId": "preset-test",
         "lastRunId": "no-run-id-provided"
     }
@@ -214,7 +214,7 @@
                                 "actor": "urn:li:corpuser:unknown"
                             },
                             "lastModified": {
-                                "time": 1586847600000,
+                                "time": 1720594800000,
                                 "actor": "urn:li:corpuser:test_username_2"
                             }
                         },
@@ -231,7 +231,7 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1586847600000,
+        "lastObserved": 1720594800000,
         "runId": "preset-test",
         "lastRunId": "no-run-id-provided"
     }
@@ -261,7 +261,7 @@
                                 "actor": "urn:li:corpuser:unknown"
                             },
                             "lastModified": {
-                                "time": 1586847600000,
+                                "time": 1720594800000,
                                 "actor": "urn:li:corpuser:test_username_2"
                             }
                         },
@@ -278,7 +278,7 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1586847600000,
+        "lastObserved": 1720594800000,
         "runId": "preset-test",
         "lastRunId": "no-run-id-provided"
     }

--- a/metadata-ingestion/tests/integration/preset/golden_test_stateful_ingest.json
+++ b/metadata-ingestion/tests/integration/preset/golden_test_stateful_ingest.json
@@ -32,7 +32,7 @@
                                 "actor": "urn:li:corpuser:unknown"
                             },
                             "lastModified": {
-                                "time": 1586847600000,
+                                "time": 1720594800000,
                                 "actor": "urn:li:corpuser:test_username_1"
                             }
                         },
@@ -43,8 +43,8 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1586847600000,
-        "runId": "preset-2020_04_14-07_00_00",
+        "lastObserved": 1720594800000,
+        "runId": "preset-2024_07_10-07_00_00",
         "lastRunId": "no-run-id-provided",
         "pipelineName": "test_pipeline"
     }
@@ -74,7 +74,7 @@
                                 "actor": "urn:li:corpuser:unknown"
                             },
                             "lastModified": {
-                                "time": 1586847600000,
+                                "time": 1720594800000,
                                 "actor": "urn:li:corpuser:test_username_1"
                             }
                         },
@@ -91,8 +91,8 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1586847600000,
-        "runId": "preset-2020_04_14-07_00_00",
+        "lastObserved": 1720594800000,
+        "runId": "preset-2024_07_10-07_00_00",
         "lastRunId": "no-run-id-provided",
         "pipelineName": "test_pipeline"
     }
@@ -122,7 +122,7 @@
                                 "actor": "urn:li:corpuser:unknown"
                             },
                             "lastModified": {
-                                "time": 1586847600000,
+                                "time": 1720594800000,
                                 "actor": "urn:li:corpuser:test_username_1"
                             }
                         },
@@ -139,8 +139,8 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1586847600000,
-        "runId": "preset-2020_04_14-07_00_00",
+        "lastObserved": 1720594800000,
+        "runId": "preset-2024_07_10-07_00_00",
         "lastRunId": "no-run-id-provided",
         "pipelineName": "test_pipeline"
     }
@@ -170,7 +170,7 @@
                                 "actor": "urn:li:corpuser:unknown"
                             },
                             "lastModified": {
-                                "time": 1586847600000,
+                                "time": 1720594800000,
                                 "actor": "urn:li:corpuser:test_username_2"
                             }
                         },
@@ -187,8 +187,8 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1586847600000,
-        "runId": "preset-2020_04_14-07_00_00",
+        "lastObserved": 1720594800000,
+        "runId": "preset-2024_07_10-07_00_00",
         "lastRunId": "no-run-id-provided",
         "pipelineName": "test_pipeline"
     }
@@ -218,7 +218,7 @@
                                 "actor": "urn:li:corpuser:unknown"
                             },
                             "lastModified": {
-                                "time": 1586847600000,
+                                "time": 1720594800000,
                                 "actor": "urn:li:corpuser:test_username_2"
                             }
                         },
@@ -235,8 +235,8 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1586847600000,
-        "runId": "preset-2020_04_14-07_00_00",
+        "lastObserved": 1720594800000,
+        "runId": "preset-2024_07_10-07_00_00",
         "lastRunId": "no-run-id-provided",
         "pipelineName": "test_pipeline"
     }
@@ -252,8 +252,8 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1586847600000,
-        "runId": "preset-2020_04_14-07_00_00",
+        "lastObserved": 1720594800000,
+        "runId": "preset-2024_07_10-07_00_00",
         "lastRunId": "no-run-id-provided",
         "pipelineName": "test_pipeline"
     }

--- a/metadata-ingestion/tests/integration/preset/golden_test_stateful_ingest.json
+++ b/metadata-ingestion/tests/integration/preset/golden_test_stateful_ingest.json
@@ -1,0 +1,261 @@
+[
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DashboardSnapshot": {
+            "urn": "urn:li:dashboard:(preset,1)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.dashboard.DashboardInfo": {
+                        "customProperties": {
+                            "Status": "published",
+                            "IsPublished": "true",
+                            "Owners": "test_username_1, test_username_2",
+                            "IsCertified": "true",
+                            "CertifiedBy": "Certification team",
+                            "CertificationDetails": "Approved"
+                        },
+                        "title": "test_dashboard_title_1",
+                        "description": "",
+                        "charts": [
+                            "urn:li:chart:(preset,10)",
+                            "urn:li:chart:(preset,11)"
+                        ],
+                        "datasets": [],
+                        "lastModified": {
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1586847600000,
+                                "actor": "urn:li:corpuser:test_username_1"
+                            }
+                        },
+                        "dashboardUrl": "mock://mock-domain.preset.io/dashboard/test_dashboard_url_1"
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "preset-2020_04_14-07_00_00",
+        "lastRunId": "no-run-id-provided",
+        "pipelineName": "test_pipeline"
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.ChartSnapshot": {
+            "urn": "urn:li:chart:(preset,10)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.chart.ChartInfo": {
+                        "customProperties": {
+                            "Metrics": "",
+                            "Filters": "",
+                            "Dimensions": ""
+                        },
+                        "title": "test_chart_title_1",
+                        "description": "",
+                        "lastModified": {
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1586847600000,
+                                "actor": "urn:li:corpuser:test_username_1"
+                            }
+                        },
+                        "chartUrl": "mock://mock-domain.preset.io/explore/test_chart_url_10",
+                        "inputs": [
+                            {
+                                "string": "urn:li:dataset:(urn:li:dataPlatform:external,test_database_name.test_schema_name.test_table_name,PROD)"
+                            }
+                        ],
+                        "type": "BAR"
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "preset-2020_04_14-07_00_00",
+        "lastRunId": "no-run-id-provided",
+        "pipelineName": "test_pipeline"
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.ChartSnapshot": {
+            "urn": "urn:li:chart:(preset,11)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.chart.ChartInfo": {
+                        "customProperties": {
+                            "Metrics": "",
+                            "Filters": "",
+                            "Dimensions": ""
+                        },
+                        "title": "test_chart_title_2",
+                        "description": "",
+                        "lastModified": {
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1586847600000,
+                                "actor": "urn:li:corpuser:test_username_1"
+                            }
+                        },
+                        "chartUrl": "mock://mock-domain.preset.io/explore/test_chart_url_11",
+                        "inputs": [
+                            {
+                                "string": "urn:li:dataset:(urn:li:dataPlatform:external,test_database_name.test_schema_name.test_table_name,PROD)"
+                            }
+                        ],
+                        "type": "PIE"
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "preset-2020_04_14-07_00_00",
+        "lastRunId": "no-run-id-provided",
+        "pipelineName": "test_pipeline"
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.ChartSnapshot": {
+            "urn": "urn:li:chart:(preset,12)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.chart.ChartInfo": {
+                        "customProperties": {
+                            "Metrics": "",
+                            "Filters": "",
+                            "Dimensions": ""
+                        },
+                        "title": "test_chart_title_3",
+                        "description": "",
+                        "lastModified": {
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1586847600000,
+                                "actor": "urn:li:corpuser:test_username_2"
+                            }
+                        },
+                        "chartUrl": "mock://mock-domain.preset.io/explore/test_chart_url_12",
+                        "inputs": [
+                            {
+                                "string": "urn:li:dataset:(urn:li:dataPlatform:external,test_database_name.test_schema_name.test_table_name,PROD)"
+                            }
+                        ],
+                        "type": "AREA"
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "preset-2020_04_14-07_00_00",
+        "lastRunId": "no-run-id-provided",
+        "pipelineName": "test_pipeline"
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.ChartSnapshot": {
+            "urn": "urn:li:chart:(preset,13)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.chart.ChartInfo": {
+                        "customProperties": {
+                            "Metrics": "",
+                            "Filters": "",
+                            "Dimensions": ""
+                        },
+                        "title": "test_chart_title_4",
+                        "description": "",
+                        "lastModified": {
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 1586847600000,
+                                "actor": "urn:li:corpuser:test_username_2"
+                            }
+                        },
+                        "chartUrl": "mock://mock-domain.preset.io/explore/test_chart_url_13",
+                        "inputs": [
+                            {
+                                "string": "urn:li:dataset:(urn:li:dataPlatform:external,test_database_name.test_schema_name.test_table_name,PROD)"
+                            }
+                        ],
+                        "type": "HISTOGRAM"
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "preset-2020_04_14-07_00_00",
+        "lastRunId": "no-run-id-provided",
+        "pipelineName": "test_pipeline"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(preset,2)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": true
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "preset-2020_04_14-07_00_00",
+        "lastRunId": "no-run-id-provided",
+        "pipelineName": "test_pipeline"
+    }
+}
+]

--- a/metadata-ingestion/tests/integration/preset/test_preset.py
+++ b/metadata-ingestion/tests/integration/preset/test_preset.py
@@ -1,0 +1,341 @@
+from typing import Any, Dict
+from unittest.mock import patch
+
+import pytest
+from freezegun import freeze_time
+
+from datahub.ingestion.run.pipeline import Pipeline
+from tests.test_helpers import mce_helpers
+from tests.test_helpers.state_helpers import (
+    get_current_checkpoint_from_pipeline,
+    run_and_get_pipeline,
+    validate_all_providers_have_committed_successfully,
+)
+
+FROZEN_TIME = "2020-04-14 07:00:00"
+GMS_PORT = 8080
+GMS_SERVER = f"http://localhost:{GMS_PORT}"
+
+
+def register_mock_api(request_mock: Any, override_data: dict = {}) -> None:
+    api_vs_response = {
+        "mock://mock-domain.preset.io/v1/auth/": {
+            "method": "POST",
+            "status_code": 200,
+            "json": {"payload": {
+                "access_token": "test_token",
+            }},
+        },
+        "mock://mock-domain.preset.io/api/v1/dashboard/": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {
+                "count": 2,
+                "result": [
+                    {
+                        "id": "1",
+                        "changed_by": {
+                            "username": "test_username_1",
+                        },
+                        "changed_on_utc": "2020-04-14T07:00:00.000000+0000",
+                        "dashboard_title": "test_dashboard_title_1",
+                        "url": "/dashboard/test_dashboard_url_1",
+                        "position_json": '{"CHART-test-1": {"meta": { "chartId": "10" }}, "CHART-test-2": {"meta": { "chartId": "11" }}}',
+                        "status": "published",
+                        "published": True,
+                        "owners": [
+                            {
+                                "username": "test_username_1",
+                            },
+                            {
+                                "username": "test_username_2",
+                            },
+                        ],
+                        "certified_by": "Certification team",
+                        "certification_details": "Approved",
+                    },
+                    {
+                        "id": "2",
+                        "changed_by": {
+                            "username": "test_username_2",
+                        },
+                        "changed_on_utc": "2020-04-14T07:00:00.000000+0000",
+                        "dashboard_title": "test_dashboard_title_2",
+                        "url": "/dashboard/test_dashboard_url_2",
+                        "position_json": '{"CHART-test-3": {"meta": { "chartId": "12" }}, "CHART-test-4": {"meta": { "chartId": "13" }}}',
+                        "status": "draft",
+                        "published": False,
+                        "owners": [
+                            {
+                                "first_name": "name",
+                            },
+                        ],
+                        "certified_by": "",
+                        "certification_details": "",
+                    },
+                ],
+            },
+        },
+        "mock://mock-domain.preset.io/api/v1/chart/": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {
+                "count": 4,
+                "result": [
+                    {
+                        "id": "10",
+                        "changed_by": {
+                            "username": "test_username_1",
+                        },
+                        "changed_on_utc": "2020-04-14T07:00:00.000000+0000",
+                        "slice_name": "test_chart_title_1",
+                        "viz_type": "box_plot",
+                        "url": "/explore/test_chart_url_10",
+                        "datasource_id": "20",
+                        "params": '{"metrics": [], "adhoc_filters": []}',
+                    },
+                    {
+                        "id": "11",
+                        "changed_by": {
+                            "username": "test_username_1",
+                        },
+                        "changed_on_utc": "2020-04-14T07:00:00.000000+0000",
+                        "slice_name": "test_chart_title_2",
+                        "viz_type": "pie",
+                        "url": "/explore/test_chart_url_11",
+                        "datasource_id": "20",
+                        "params": '{"metrics": [], "adhoc_filters": []}',
+                    },
+                    {
+                        "id": "12",
+                        "changed_by": {
+                            "username": "test_username_2",
+                        },
+                        "changed_on_utc": "2020-04-14T07:00:00.000000+0000",
+                        "slice_name": "test_chart_title_3",
+                        "viz_type": "treemap",
+                        "url": "/explore/test_chart_url_12",
+                        "datasource_id": "20",
+                        "params": '{"metrics": [], "adhoc_filters": []}',
+                    },
+                    {
+                        "id": "13",
+                        "changed_by": {
+                            "username": "test_username_2",
+                        },
+                        "changed_on_utc": "2020-04-14T07:00:00.000000+0000",
+                        "slice_name": "test_chart_title_4",
+                        "viz_type": "histogram",
+                        "url": "/explore/test_chart_url_13",
+                        "datasource_id": "20",
+                        "params": '{"metrics": [], "adhoc_filters": []}',
+                    },
+                ],
+            },
+        },
+        "mock://mock-domain.preset.io/api/v1/dataset/20": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {
+                "result": {
+                    "schema": "test_schema_name",
+                    "table_name": "test_table_name",
+                    "database": {
+                        "id": "30",
+                        "database_name": "test_database_name",
+                    },
+                },
+            },
+        },
+        "mock://mock-domain.preset.io/api/v1/database/30": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {
+                "result": {
+                    "sqlalchemy_uri": "test_sqlalchemy_uri",
+                },
+            },
+        },
+    }
+
+    api_vs_response.update(override_data)
+
+    for url in api_vs_response.keys():
+        request_mock.register_uri(
+            api_vs_response[url]["method"],
+            url,
+            json=api_vs_response[url]["json"],
+            status_code=api_vs_response[url]["status_code"],
+        )
+
+
+@freeze_time(FROZEN_TIME)
+@pytest.mark.integration
+def test_preset_ingest(pytestconfig, tmp_path, mock_time, requests_mock):
+    test_resources_dir = pytestconfig.rootpath / "tests/integration/preset"
+
+    register_mock_api(request_mock=requests_mock)
+
+    pipeline = Pipeline.create(
+        {
+            "run_id": "preset-test",
+            "source": {
+                "type": "preset",
+                "config": {
+                    "connect_uri": "mock://mock-domain.preset.io/",
+                    "manager_uri": "mock://mock-domain.preset.io",
+                    "api_key": "test_key",
+                    "api_secret": "test_secret",
+                    "provider": "db",
+                },
+            },
+            "sink": {
+                "type": "file",
+                "config": {
+                    "filename": f"{tmp_path}/preset_mces.json",
+                },
+            },
+        }
+    )
+
+    pipeline.run()
+    pipeline.raise_from_status()
+    golden_file = "golden_test_ingest.json"
+
+    mce_helpers.check_golden_file(
+        pytestconfig,
+        output_path=tmp_path / "preset_mces.json",
+        golden_path=f"{test_resources_dir}/{golden_file}",
+    )
+
+
+@freeze_time(FROZEN_TIME)
+@pytest.mark.integration
+def test_preset_stateful_ingest(
+    pytestconfig, tmp_path, mock_time, requests_mock, mock_datahub_graph
+):
+    test_resources_dir = pytestconfig.rootpath / "tests/integration/preset"
+
+    register_mock_api(request_mock=requests_mock)
+
+    pipeline_config_dict: Dict[str, Any] = {
+        "source": {
+            "type": "preset",
+            "config": {
+                "connect_uri": "mock://mock-domain.preset.io/",
+                "manager_uri": "mock://mock-domain.preset.io",
+                "api_key": "test_key",
+                "api_secret": "test_secret",
+                "provider": "db",
+                # enable stateful ingestion
+                "stateful_ingestion": {
+                    "enabled": True,
+                    "remove_stale_metadata": True,
+                    "fail_safe_threshold": 100.0,
+                    "state_provider": {
+                        "type": "datahub",
+                        "config": {"datahub_api": {"server": GMS_SERVER}},
+                    },
+                },
+            },
+        },
+        "sink": {
+            # we are not really interested in the resulting events for this test
+            "type": "console"
+        },
+        "pipeline_name": "test_pipeline",
+    }
+
+    dashboard_endpoint_override = {
+        "mock://mock-domain.preset.io/api/v1/dashboard/": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {
+                "count": 1,
+                "result": [
+                    {
+                        "id": "1",
+                        "changed_by": {
+                            "username": "test_username_1",
+                        },
+                        "changed_on_utc": "2020-04-14T07:00:00.000000+0000",
+                        "dashboard_title": "test_dashboard_title_1",
+                        "url": "/dashboard/test_dashboard_url_1",
+                        "position_json": '{"CHART-test-1": {"meta": { "chartId": "10" }}, "CHART-test-2": {"meta": { "chartId": "11" }}}',
+                        "status": "published",
+                        "published": True,
+                        "owners": [
+                            {
+                                "username": "test_username_1",
+                            },
+                            {
+                                "username": "test_username_2",
+                            },
+                        ],
+                        "certified_by": "Certification team",
+                        "certification_details": "Approved",
+                    },
+                ],
+            },
+        },
+    }
+
+    with patch(
+        "datahub.ingestion.source.state_provider.datahub_ingestion_checkpointing_provider.DataHubGraph",
+        mock_datahub_graph,
+    ) as mock_checkpoint:
+        # Both checkpoint and reporting will use the same mocked graph instance.
+        mock_checkpoint.return_value = mock_datahub_graph
+
+        # Do the first run of the pipeline and get the default job's checkpoint.
+        pipeline_run1 = run_and_get_pipeline(pipeline_config_dict)
+        checkpoint1 = get_current_checkpoint_from_pipeline(pipeline_run1)
+
+        assert checkpoint1
+        assert checkpoint1.state
+
+        # Remove one dashboard from the preset config.
+        register_mock_api(
+            request_mock=requests_mock, override_data=dashboard_endpoint_override
+        )
+
+        # Capture MCEs of second run to validate Status(removed=true)
+        deleted_mces_path = f"{tmp_path}/preset_deleted_mces.json"
+        pipeline_config_dict["sink"]["type"] = "file"
+        pipeline_config_dict["sink"]["config"] = {"filename": deleted_mces_path}
+
+        # Do the second run of the pipeline.
+        pipeline_run2 = run_and_get_pipeline(pipeline_config_dict)
+        checkpoint2 = get_current_checkpoint_from_pipeline(pipeline_run2)
+
+        assert checkpoint2
+        assert checkpoint2.state
+
+        # Perform all assertions on the states. The deleted dashboard should not be
+        # part of the second state
+        state1 = checkpoint1.state
+        state2 = checkpoint2.state
+        difference_urns = list(
+            state1.get_urns_not_in(type="dashboard", other_checkpoint_state=state2)
+        )
+
+        assert len(difference_urns) == 1
+
+        urn1 = "urn:li:dashboard:(preset,2)"
+
+        assert urn1 in difference_urns
+
+        # Validate that all providers have committed successfully.
+        validate_all_providers_have_committed_successfully(
+            pipeline=pipeline_run1, expected_providers=1
+        )
+        validate_all_providers_have_committed_successfully(
+            pipeline=pipeline_run2, expected_providers=1
+        )
+
+        # Verify the output.
+        mce_helpers.check_golden_file(
+            pytestconfig,
+            output_path=deleted_mces_path,
+            golden_path=test_resources_dir / "golden_test_stateful_ingest.json",
+        )

--- a/metadata-ingestion/tests/integration/preset/test_preset.py
+++ b/metadata-ingestion/tests/integration/preset/test_preset.py
@@ -12,7 +12,7 @@ from tests.test_helpers.state_helpers import (
     validate_all_providers_have_committed_successfully,
 )
 
-FROZEN_TIME = "2020-04-14 07:00:00"
+FROZEN_TIME = "2024-07-10 07:00:00"
 GMS_PORT = 8080
 GMS_SERVER = f"http://localhost:{GMS_PORT}"
 
@@ -26,6 +26,14 @@ def register_mock_api(request_mock: Any, override_data: dict = {}) -> None:
                 "access_token": "test_token",
             }},
         },
+        "mock://mock-domain.preset.io/version": {
+            "method": "GET",
+            "status_code": 200,
+            "json": {
+                'ci': {'built_at': 'Tue Jul  10 00:00:00 UTC 2024', 'build_num': '1', 'triggered_by': 'Not triggered by a user'},
+                'git': {'branch': '4.0.1.6', 'sha': 'test_sha', 'sha_superset': 'test_sha_superset', 'release_name': 'test_release_name'},
+                'chart_version': '1.16.1', 'start_time': '2024-07-10 00:00:00', 'mt_deployment': True}
+        },
         "mock://mock-domain.preset.io/api/v1/dashboard/": {
             "method": "GET",
             "status_code": 200,
@@ -37,7 +45,7 @@ def register_mock_api(request_mock: Any, override_data: dict = {}) -> None:
                         "changed_by": {
                             "username": "test_username_1",
                         },
-                        "changed_on_utc": "2020-04-14T07:00:00.000000+0000",
+                        "changed_on_utc": "2024-07-10T07:00:00.000000+0000",
                         "dashboard_title": "test_dashboard_title_1",
                         "url": "/dashboard/test_dashboard_url_1",
                         "position_json": '{"CHART-test-1": {"meta": { "chartId": "10" }}, "CHART-test-2": {"meta": { "chartId": "11" }}}',
@@ -59,7 +67,7 @@ def register_mock_api(request_mock: Any, override_data: dict = {}) -> None:
                         "changed_by": {
                             "username": "test_username_2",
                         },
-                        "changed_on_utc": "2020-04-14T07:00:00.000000+0000",
+                        "changed_on_utc": "2024-07-10T07:00:00.000000+0000",
                         "dashboard_title": "test_dashboard_title_2",
                         "url": "/dashboard/test_dashboard_url_2",
                         "position_json": '{"CHART-test-3": {"meta": { "chartId": "12" }}, "CHART-test-4": {"meta": { "chartId": "13" }}}',
@@ -87,7 +95,7 @@ def register_mock_api(request_mock: Any, override_data: dict = {}) -> None:
                         "changed_by": {
                             "username": "test_username_1",
                         },
-                        "changed_on_utc": "2020-04-14T07:00:00.000000+0000",
+                        "changed_on_utc": "2024-07-10T07:00:00.000000+0000",
                         "slice_name": "test_chart_title_1",
                         "viz_type": "box_plot",
                         "url": "/explore/test_chart_url_10",
@@ -99,7 +107,7 @@ def register_mock_api(request_mock: Any, override_data: dict = {}) -> None:
                         "changed_by": {
                             "username": "test_username_1",
                         },
-                        "changed_on_utc": "2020-04-14T07:00:00.000000+0000",
+                        "changed_on_utc": "2024-07-10T07:00:00.000000+0000",
                         "slice_name": "test_chart_title_2",
                         "viz_type": "pie",
                         "url": "/explore/test_chart_url_11",
@@ -111,7 +119,7 @@ def register_mock_api(request_mock: Any, override_data: dict = {}) -> None:
                         "changed_by": {
                             "username": "test_username_2",
                         },
-                        "changed_on_utc": "2020-04-14T07:00:00.000000+0000",
+                        "changed_on_utc": "2024-07-10T07:00:00.000000+0000",
                         "slice_name": "test_chart_title_3",
                         "viz_type": "treemap",
                         "url": "/explore/test_chart_url_12",
@@ -123,7 +131,7 @@ def register_mock_api(request_mock: Any, override_data: dict = {}) -> None:
                         "changed_by": {
                             "username": "test_username_2",
                         },
-                        "changed_on_utc": "2020-04-14T07:00:00.000000+0000",
+                        "changed_on_utc": "2024-07-10T07:00:00.000000+0000",
                         "slice_name": "test_chart_title_4",
                         "viz_type": "histogram",
                         "url": "/explore/test_chart_url_13",
@@ -258,7 +266,7 @@ def test_preset_stateful_ingest(
                         "changed_by": {
                             "username": "test_username_1",
                         },
-                        "changed_on_utc": "2020-04-14T07:00:00.000000+0000",
+                        "changed_on_utc": "2024-07-10T07:00:00.000000+0000",
                         "dashboard_title": "test_dashboard_title_1",
                         "url": "/dashboard/test_dashboard_url_1",
                         "position_json": '{"CHART-test-1": {"meta": { "chartId": "10" }}, "CHART-test-2": {"meta": { "chartId": "11" }}}',

--- a/metadata-ingestion/tests/unit/test_preset_source.py
+++ b/metadata-ingestion/tests/unit/test_preset_source.py
@@ -1,0 +1,21 @@
+from src.datahub.ingestion.source.preset import PresetConfig
+
+def test_default_values():
+    config = PresetConfig.parse_obj({})
+
+    assert config.connect_uri == "https://api.app.preset.io"
+    assert config.manager_uri == "https://api.app.preset.io"
+    assert config.display_uri == "https://api.app.preset.io"
+    assert config.env == "PROD"
+    assert config.api_key is None
+    assert config.api_secret is None
+
+
+def test_set_display_uri():
+    display_uri = "some_host:1234"
+
+    config = PresetConfig.parse_obj({"display_uri": display_uri})
+
+    assert config.connect_uri == "https://api.app.preset.io"
+    assert config.manager_uri == "https://api.app.preset.io"
+    assert config.display_uri == display_uri

--- a/metadata-ingestion/tests/unit/test_preset_source.py
+++ b/metadata-ingestion/tests/unit/test_preset_source.py
@@ -3,9 +3,9 @@ from src.datahub.ingestion.source.preset import PresetConfig
 def test_default_values():
     config = PresetConfig.parse_obj({})
 
-    assert config.connect_uri == "https://api.app.preset.io"
+    assert config.connect_uri is None
     assert config.manager_uri == "https://api.app.preset.io"
-    assert config.display_uri == "https://api.app.preset.io"
+    assert config.display_uri is None
     assert config.env == "PROD"
     assert config.api_key is None
     assert config.api_secret is None
@@ -16,6 +16,6 @@ def test_set_display_uri():
 
     config = PresetConfig.parse_obj({"display_uri": display_uri})
 
-    assert config.connect_uri == "https://api.app.preset.io"
+    assert config.connect_uri is None
     assert config.manager_uri == "https://api.app.preset.io"
     assert config.display_uri == display_uri


### PR DESCRIPTION
## Checklist
Adding Preset Integration and unit tests for the Preset ingestion method.

`Test setup:`
- [https://datahubproject.io/docs/metadata-ingestion/developing/#:~:text=all dev requirements.-,pip install -e '.[dev]',-%23 For running integration](https://datahubproject.io/docs/metadata-ingestion/developing/#:~:text=all%20dev%20requirements.-,pip%20install%20-e%20%27.%5Bdev%5D%27,-%23%20For%20running%20integration)
- linting: ./gradlew :metadata-ingestion:lintFix
- Need to first install dependencies:
    ```sql
    cd metadata-ingestion
    ../gradlew :metadata-ingestion:installDev
    source venv/bin/activate
    datahub version  # should print "DataHub CLI version: unavailable (installed in develop mode)"
    ```
    
- For pytest:
    - `run pytest tests/integration/preset/test_preset.py`
    - `run pytest tests/unit/test_preset_source.py`


- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
