### PR TITLE
split ownership pr

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/preset.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/preset.py
@@ -80,8 +80,6 @@ class PresetSource(SupersetSource):
     platform = "preset"
 
     def __init__(self, ctx: PipelineContext, config: PresetConfig):
-        logger.info(f"ctx is {ctx}")
-
         super().__init__(ctx, config)
         self.config = config
         self.report = StaleEntityRemovalSourceReport()

--- a/metadata-ingestion/src/datahub/ingestion/source/superset.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/superset.py
@@ -547,10 +547,13 @@ class SupersetSource(StatefulIngestionSourceBase):
         chart_url = f"{self.config.display_uri}{chart_data.get('url', '')}"
 
         datasource_id = chart_data.get("datasource_id")
-        dataset_response = self.get_dataset_info(datasource_id)
-        datasource_urn = self.get_datasource_urn_from_id(
-            dataset_response, self.platform
-        )
+        if not datasource_id:
+            logger.warning(f'chart {chart_data["id"]} has no datasource_id, skipping fetching dataset info')
+        else:
+            dataset_response = self.get_dataset_info(datasource_id)
+            datasource_urn = self.get_datasource_urn_from_id(
+                dataset_response, self.platform
+            )
 
         params = json.loads(chart_data.get("params", "{}"))
         metrics = [

--- a/metadata-ingestion/src/datahub/ingestion/source/superset.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/superset.py
@@ -548,12 +548,13 @@ class SupersetSource(StatefulIngestionSourceBase):
 
         datasource_id = chart_data.get("datasource_id")
         if not datasource_id:
-            logger.warning(f'chart {chart_data["id"]} has no datasource_id, skipping fetching dataset info')
+            logger.debug(f'chart {chart_data["id"]} has no datasource_id, skipping fetching dataset info')
+            datasource_urn = None
         else:
             dataset_response = self.get_dataset_info(datasource_id)
-            datasource_urn = self.get_datasource_urn_from_id(
+            datasource_urn = list(self.get_datasource_urn_from_id(
                 dataset_response, self.platform
-            )
+            ))
 
         params = json.loads(chart_data.get("params", "{}"))
         metrics = [
@@ -598,7 +599,7 @@ class SupersetSource(StatefulIngestionSourceBase):
             title=title,
             lastModified=last_modified,
             chartUrl=chart_url,
-            inputs=[datasource_urn] if datasource_urn else None,
+            inputs=datasource_urn,
             customProperties=custom_properties,
         )
         chart_snapshot.aspects.append(chart_info)

--- a/metadata-ingestion/src/datahub/ingestion/source/superset.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/superset.py
@@ -360,14 +360,16 @@ class SupersetSource(StatefulIngestionSourceBase):
             )
         raise ValueError("Could not construct dataset URN")
     
-    def parse_owner_payload(self, payload: dict, owners_dict: dict) -> None:
+    def parse_owner_payload(self, payload: dict) -> dict:
+        owners_dict = {}
         for owner_data in payload.get("result", []):
             email = owner_data.get("extra", {}).get("email")
             value = owner_data.get("value")
 
-            if value and email and value not in owners_dict:
+            if value and email:
                 owners_dict[value] = email
-
+        return owners_dict
+    
     def build_preset_owner_dict(self) -> Dict[str, str]: 
         owners_dict = {}
         dataset_payload = self.get_all_entity_owners("dataset")


### PR DESCRIPTION
This feature syncs in Dataset, Chart, Dashboard owners listed on Preset into Datahub. 

**Screenshot of a Dataset with owners:**
<img width="961" alt="Screenshot 2024-11-19 at 9 41 01 AM" src="https://github.com/user-attachments/assets/d513dba1-418c-4925-aea5-3099c2f664ef">

**Screenshot of a Chart with owners:**
<img width="959" alt="Screenshot 2024-11-19 at 9 42 21 AM" src="https://github.com/user-attachments/assets/73602dc6-8f4f-4c96-91c1-f3348a68f081">

**Screenshot of a Dashboard with owners:**
<img width="959" alt="Screenshot 2024-11-19 at 9 45 04 AM" src="https://github.com/user-attachments/assets/bc1f0730-9903-4e09-879b-6b820e146861">


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
